### PR TITLE
Refactor for `@ChangeTracked` and stylesheets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/liveviewnative/liveview-client-swiftui.git", branch: "main"),
+        .package(url: "https://github.com/liveviewnative/liveview-client-swiftui.git", branch: "content-builder-stylesheets"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/LiveViewNativeAVKit/AVKitRegistry.swift
+++ b/Sources/LiveViewNativeAVKit/AVKitRegistry.swift
@@ -22,7 +22,7 @@ public struct AVKitRegistry<Root: RootRegistry>: CustomRegistry {
     public static func lookup(_ name: TagName, element: ElementNode) -> some View {
         switch name {
         case .videoPlayer:
-            VideoPlayerView<Root>(element: element)
+            VideoPlayerView<Root>()
         }
     }
 }

--- a/Sources/LiveViewNativeAVKit/VideoPlayerView.swift
+++ b/Sources/LiveViewNativeAVKit/VideoPlayerView.swift
@@ -13,56 +13,26 @@ import LiveViewNative
 import CoreMedia
 
 /// A native video player view. It can be rendered in a LiveViewNative app using the `VideoPlayer` element.
-/// 
+///
+/// - Note: You must include a `phx-throttle` or `phx-debounce` attribute to receive updates to the `playback-time`.
+///
 /// ```elixir
-/// defmodule MyApp.VideoPlayerLive do
-///   use Phoenix.LiveView
-///   use LiveViewNative.LiveView
-/// 
-///   native_binding :is_muted, Atom, false
-///   native_binding :time_control_status, String, ""
-///   native_binding :playback_time, Float, 5.0
-///   native_binding :playback_time_update_interval, Float, 0.05
-/// 
-///   @impl true
-///   def render(%{platform_id: :swiftui} = assigns) do
-///     ~SWIFTUI"""
-///     <VStack id="webview-example">
-///       <VStack>
-///         <%= @playback_time %>
-///       </VStack>
-///       <VideoPlayer
-///         autoplay
-///         is-muted="is_muted"
-///         playback-time="playback_time"
-///         playback-time-update-interval="playback_time_update_interval"
-///         on-play="handle_play"
-///         on-pause="handle_pause"
-///         time-control-status="time_control_status"
-///         url="http://192.168.1.143:4000/videos/sample2.mp4"
-///         volume="volume" />
-///     </VStack>
-///     """
-///   end
-/// end
+/// <VideoPlayer
+///   autoplay
+///   is-muted
+///   url="http://192.168.1.143:4000/videos/sample2.mp4"
+///   playback-time={30}
+///   phx-debounce={1000}
+///   phx-change="player-changed"
+/// />
 /// ```
 ///
 /// ## Attributes
 /// * ``autoplay``
 /// * ``url``
-///
-/// ## Bindings
 /// * ``isMuted``
 /// * ``playbackTime``
-/// * ``playbackTimeUpdateInterval``
 /// * ``timeControlStatus``
-///
-/// ## Events
-/// - ``pauseEvent``
-/// - ``playEvent``
-#if swift(>=5.8)
-@_documentation(visibility: public)
-#endif
 struct VideoPlayerView<R: RootRegistry>: View {
     @StateObject private var coordinator = VideoPlayerCoordinator()
     

--- a/Sources/LiveViewNativeAVKit/VideoPlayerView.swift
+++ b/Sources/LiveViewNativeAVKit/VideoPlayerView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import AVFoundation
 import AVKit
 import LiveViewNative
@@ -63,172 +64,142 @@ import CoreMedia
 @_documentation(visibility: public)
 #endif
 struct VideoPlayerView<R: RootRegistry>: View {
-    /// An event that is fired when the video player is paused.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @Event("on-pause", type: "click") private var pause
-
-    /// An event that is fired when the video player is played.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @Event("on-play", type: "click") private var play
-
-    /// A boolean indicating whether the video player is muted.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @LiveBinding(attribute: "is-muted") private var isMuted: Bool
-
-    /// The current playback time of the video player in seconds.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @LiveBinding(attribute: "playback-time") private var playbackTime: Double
-
-    /// The current time control status of the video player (playing, paused, etc.).
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @LiveBinding(attribute: "time-control-status") private var timeControlStatus: TimeControlStatus = .unknown
-
-    /// If true, the video will play when the view appears.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @Attribute("autoplay") private var autoplay: Bool
-
-    /// The interval at which the playback time is updated.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @Attribute("playback-time-update-interval") private var playbackTimeUpdateInterval: Double
-
+    @StateObject private var coordinator = VideoPlayerCoordinator()
+    
     /// The URL of the video to play.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
     @Attribute("url", transform: {
         guard let value = $0?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
 
         return URL(string: value)!
     }) private var url: URL
+    
+    /// If true, the video will play when the view appears.
+    @Attribute("autoplay") private var autoplay: Bool
+    
+    @Attribute("phx-debounce") private var debounce: Double?
+    @Attribute("phx-throttle") private var throttle: Double?
+
+    /// A boolean indicating whether the video player is muted.
+    @ChangeTracked(attribute: "is-muted") private var isMuted: Bool = false
+
+    /// The current playback time of the video player in seconds.
+    @Attribute("playback-time") private var playbackTime: Double?
+    /// The name of the change event. Used by ``playbackTime`` to bypass the default debounce/throttle behavior.
+    @Attribute("phx-change") private var changeEventName: String
+
+    /// The current time control status of the video player (playing, paused, etc.).
+    @ChangeTracked(attribute: "time-control-status") private var timeControlStatus: TimeControlStatus = .paused
 
     @LiveContext<R> private var context
     @ObservedElement private var element: ElementNode
-    @StateObject private var observer: VideoPlayerObserver<R>
-
-    init(element: ElementNode) {
-        let seconds = element.attributeValue(for: "playback-time-update-interval").flatMap(Double.init(_:))
-        let interval = CMTime(seconds: seconds!, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-
-        _observer = StateObject(wrappedValue: VideoPlayerObserver(interval: interval))
-    }
-
+    
     var body: some View {
-        VideoPlayer(player: self.observer.player)
-            .task { initPlayer() }
-            .onChange(of: isMuted) { value in observer.player.isMuted = value }
-            .onReceive(context.coordinator.receiveEvent("pause"), perform: performPause)
-            .onReceive(context.coordinator.receiveEvent("play"), perform: performPlay)
-            .onReceive(context.coordinator.receiveEvent("seek"), perform: performSeek)
-            .onReceive(observer.player.publisher(for: \.isMuted)) { value in isMuted = value }
-            .onReceive(observer.player.publisher(for: \.timeControlStatus)) { value in syncTimeControlStatus(status: value) }
-            .onReceive(observer.$playbackTime.throttle(for: .init(playbackTimeUpdateInterval), scheduler: RunLoop.current, latest: true)) { value in playbackTime = value }
-    }
-    
-    func initPlayer() {
-        timeControlStatus = .paused
-        observer.player.replaceCurrentItem(with: AVPlayerItem(url: url))
-
-        if self.autoplay {
-            self.observer.player.play()
+        VideoPlayer(player: coordinator.player) {
+            context.buildChildren(of: element)
+        }
+        // remote changes
+        .onChange(of: url) { newValue in
+            coordinator.setPlayerItem(newValue)
+        }
+        .onChange(of: isMuted) {
+            coordinator.player.isMuted = $0
+        }
+        .onChange(of: playbackTime) {
+            if let playbackTime = $0,
+               playbackTime != coordinator.playbackTime.value
+            {
+                coordinator.player.seek(to: CMTimeMakeWithSeconds(playbackTime, preferredTimescale: 1))
+            }
+        }
+        .onChange(of: timeControlStatus) {
+            switch $0 {
+            case .paused:
+                coordinator.player.pause()
+            case .playing:
+                coordinator.player.play()
+            default:
+                break
+            }
+        }
+        // local changes
+        .onReceive(coordinator.player.publisher(for: \.isMuted)) {
+            isMuted = $0
+        }
+        .onReceive(coordinator.playbackTime) { playbackTime in
+            guard let playbackTime else { return }
+            Task {
+                // send a change event without automatic debouncing, the observer handles the debounce instead.
+                try await context.coordinator.pushEvent(
+                    type: "click",
+                    event: changeEventName,
+                    value: ["playback-time": playbackTime],
+                    target: element.attributeValue(for: "phx-target").flatMap(Int.init)
+                )
+            }
+        }
+        .onReceive(coordinator.player.publisher(for: \.timeControlStatus)) {
+            timeControlStatus = .init($0)
+        }
+        // setup
+        .task {
+            coordinator.setPlayerItem(url)
+        }
+        .onChange(of: debounce ?? throttle) {
+            coordinator.setupTimeObserver($0)
+        }
+        .onChange(of: coordinator.player.currentItem) { item in
+            coordinator.player.seek(to: CMTimeMakeWithSeconds(playbackTime ?? 0, preferredTimescale: 1))
+            coordinator.setupTimeObserver(debounce ?? throttle)
+            if autoplay {
+                coordinator.player.play()
+            }
         }
     }
-
-    func performPlay(params: Dictionary<String, Any>) {
-        observer.player.play()
-    }
-
-    func performPause(params: Dictionary<String, Any>) {
-        observer.player.pause()
-    }
-
-    func performSeek(params: Dictionary<String, Any>) {
-        guard let value = params["playback_time"] as? Double else { return }
-        
-        let to = CMTimeMakeWithSeconds(value, preferredTimescale: 1)
-        let toleranceBefore = CMTimeMakeWithSeconds(0.0, preferredTimescale: 1)
-        let toleranceAfter = CMTimeMakeWithSeconds(0.0, preferredTimescale: 1)
-
-        observer.player.seek(to: to, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
-
-        // Always update playback time when seeking.
-        playbackTime = CMTimeGetSeconds(observer.player.currentTime())
-    }
     
-    func syncPlaybackTime() {
-        let time = observer.player.currentTime()
+    /// An observer for a `VideoPlayerView` that watches for changes to an `AVPlayer` instance
+    /// along with other properties through the `VideoPlayerObserver.Assigns` class.
+    final class VideoPlayerCoordinator: ObservableObject {
+        let player: AVPlayer = .init()
         
-        guard time != .invalid && time != .indefinite
-        else { return }
-
-        playbackTime = CMTimeGetSeconds(time)
-    }
-
-    func syncTimeControlStatus(status: AVPlayer.TimeControlStatus) {
-        switch (status) {
-        case .paused:
-            /// Call `pauseEvent`` if the time control status has changed to paused from another state.
-            if timeControlStatus != .paused {
-                pause(value: ["playback_time": playbackTime])
-            }
-            syncPlaybackTime()
-            timeControlStatus = .paused
-
-        case .playing:
-            /// Call `playEvent` if the time control status has changed to paused from another state.
-            if timeControlStatus != .playing {
-                play(value: ["playback_time": playbackTime])
-            }
-            syncPlaybackTime()
-            timeControlStatus = .playing
-
-        case .waitingToPlayAtSpecifiedRate:
-            timeControlStatus = .waitingToPlayAtSpecifiedRate
-
-        @unknown default:
-            timeControlStatus = .unknown
+        var timeObserver: Any?
+        
+        var playbackTime = CurrentValueSubject<Double?, Never>(nil)
+        
+        init() {}
+        
+        func setPlayerItem(_ url: URL) {
+            player.replaceCurrentItem(with: AVPlayerItem(url: url))
         }
-    }
-
-    enum TimeControlStatus: String, Codable {
-        case playing
-        case paused
-        case waitingToPlayAtSpecifiedRate
-        case unknown
+        
+        func setupTimeObserver(_ interval: Double?) {
+            if let timeObserver {
+                player.removeTimeObserver(timeObserver)
+            }
+            if let interval {
+                player.addPeriodicTimeObserver(
+                    forInterval: CMTime(seconds: interval / 1000, preferredTimescale: CMTimeScale(NSEC_PER_SEC)),
+                    queue: .main
+                ) { [weak self] time in
+                    self?.playbackTime.value = CMTimeGetSeconds(time)
+                }
+            }
+        }
     }
 }
 
-/// An observer for a `VideoPlayerView` that watches for changes to an `AVPlayer` instance
-/// along with other properties through the `VideoPlayerObserver.Assigns` class.
-#if swift(>=5.8)
-@_documentation(visibility: public)
-#endif
-class VideoPlayerObserver<R: RootRegistry>: ObservableObject {
-    @Published var playbackTime: Double = 0.0
-
-    var player: AVPlayer
-    var interval: CMTime
-
-    init(interval: CMTime) {
-        self.player = AVPlayer()
-        self.interval = interval
-
-        // Add time observer. Invoke closure on the main queue.
-        player.addPeriodicTimeObserver(forInterval: interval, queue: .main) {
-            [weak self] time in self?.playbackTime = CMTimeGetSeconds(time)
+enum TimeControlStatus: String, AttributeDecodable, Codable, Equatable {
+    case playing
+    case paused
+    case waitingToPlayAtSpecifiedRate
+    
+    init(_ value: AVPlayer.TimeControlStatus) {
+        switch value {
+        case .paused:
+            self = .paused
+        case .waitingToPlayAtSpecifiedRate:
+            self = .waitingToPlayAtSpecifiedRate
+        case .playing:
+            self = .playing
         }
     }
 }


### PR DESCRIPTION
* `LiveBinding` was replaced with `ChangeTracked`.
* The `pause`, `play`, and `seek` events were removed. Use the attributes `time-control-status` and `playback-time` instead

Here's a small example of how the element can be used:

> [!Note]
> You must provide a `phx-throttle` or `phx-debounce` attribute to receive updates for the `playback-time`.

```ex
defmodule MyAppWeb.IndexLive do
  use MyAppWeb, :live_view
  use MyAppWeb.Styles.AppStyles

  def mount(_params, _session, socket) do
    {:ok, assign(socket, playbackTime: 30, isMuted: false, timeControlStatus: "paused")}
  end

  def render(%{format: :swiftui} = assigns) do
    ~SWIFTUI"""
    <VStack>
      <VideoPlayer
        url="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
        autoplay
        playback-time={@playbackTime}
        phx-throttle={1000}
        is-muted={@isMuted}
        time-control-status={@timeControlStatus}
        phx-change="player-changed"
        class="aspect-video"
      />
      <Text class="title">Big Buck Bunny</Text>
      <List>
        <LabeledContent>
          <Text template="label">Playback Time</Text>
          <%= @playbackTime %>
        </LabeledContent>
        <Button phx-click="random-time">Random Time</Button>
        <LabeledContent>
          <Text template="label">Muted</Text>
          <%= @isMuted %>
        </LabeledContent>
        <Button phx-click="toggle-mute">Toggle Mute</Button>
        <LabeledContent>
          <Text template="label">Status</Text>
          <%= @timeControlStatus %>
        </LabeledContent>
        <Button phx-click="toggle-status">Toggle Play/Pause</Button>
      </List>
    </VStack>
    """
  end

  def handle_event("player-changed", %{ "playback-time" => playbackTime }, socket) do
    {:noreply, assign(socket, playbackTime: playbackTime)}
  end

  def handle_event("player-changed", %{ "is-muted" => isMuted }, socket) do
    {:noreply, assign(socket, isMuted: isMuted)}
  end

  def handle_event("player-changed", %{ "time-control-status" => timeControlStatus }, socket) do
    {:noreply, assign(socket, timeControlStatus: timeControlStatus)}
  end

  def handle_event("random-time", _params, socket) do
    {:noreply, assign(socket, playbackTime: :rand.uniform(100))}
  end

  def handle_event("toggle-mute", _params, socket) do
    {:noreply, assign(socket, isMuted: !socket.assigns.isMuted)}
  end

  def handle_event("toggle-status", _params, socket) do
    {:noreply, assign(socket, timeControlStatus: (if socket.assigns.timeControlStatus == "paused", do: "playing", else: "paused"))}
  end
end
```

https://github.com/liveview-native/liveview-native-swiftui-avkit/assets/13581484/0594fa12-3882-4652-ab0a-d6a3acbcd005
