### PR TITLE
Update to use the `@Addon` macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/liveview-native/liveview-client-swiftui.git", from: "0.3.0-rc.1"),
+        .package(url: "https://github.com/liveview-native/liveview-client-swiftui.git", branch: "main"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Usage
 
-Import `LiveViewNativeAVKit` and add the `AVKitRegistry` to the list of addons on your `LiveView`:
+Import `LiveViewNativeAVKit` and add `.avKit` to the list of addons on your `LiveView`:
 
 ```swift
 import SwiftUI
@@ -21,7 +21,7 @@ struct ContentView: View {
     var body: some View {
         #LiveView(
             .localhost,
-            addons: [AVKitRegistry<_>.self]
+            addons: [.avKit]
         )
     }
 }

--- a/Sources/LiveViewNativeAVKit/AVKitRegistry.swift
+++ b/Sources/LiveViewNativeAVKit/AVKitRegistry.swift
@@ -9,21 +9,26 @@ import LiveViewNative
 import LiveViewNativeStylesheet
 import SwiftUI
 
-/// The main LiveView Native registry for the LiveViewNativeAVKit add-on library.
-///
-/// Use this view in your LiveView view tree using the ``CustomRegistry`` (see <doc:AddCustomElement>).
-#if swift(>=5.8)
-@_documentation(visibility: public)
-#endif
-public struct AVKitRegistry<Root: RootRegistry>: CustomRegistry {
-    public enum TagName: String {
-        case videoPlayer = "VideoPlayer"
-    }
+public extension Addons {
+    public typealias AVKit = AvKit
     
-    public static func lookup(_ name: TagName, element: ElementNode) -> some View {
-        switch name {
-        case .videoPlayer:
-            VideoPlayer<Root>()
+    /// The main LiveView Native registry for the LiveViewNativeAVKit add-on library.
+    ///
+    /// Use this view in your LiveView view tree using the ``CustomRegistry`` (see <doc:AddCustomElement>).
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @Addon
+    public struct AvKit<Root: RootRegistry> {
+        public enum TagName: String {
+            case videoPlayer = "VideoPlayer"
+        }
+        
+        public static func lookup(_ name: TagName, element: ElementNode) -> some View {
+            switch name {
+            case .videoPlayer:
+                VideoPlayer<Root>()
+            }
         }
     }
 }

--- a/Sources/LiveViewNativeAVKit/AVKitRegistry.swift
+++ b/Sources/LiveViewNativeAVKit/AVKitRegistry.swift
@@ -10,11 +10,10 @@ import LiveViewNativeStylesheet
 import SwiftUI
 
 public extension Addons {
+    /// An alias for the ``AvKit`` addon, with proper capitalization when using it as a type.
     public typealias AVKit = AvKit
     
     /// The main LiveView Native registry for the LiveViewNativeAVKit add-on library.
-    ///
-    /// Use this view in your LiveView view tree using the ``CustomRegistry`` (see <doc:AddCustomElement>).
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif


### PR DESCRIPTION
Currently, the `@Addon` macro is only available on the `main` branch of `liveview-client-swiftui`. This should depend on a specific release instead before merging.